### PR TITLE
Allow custom install path

### DIFF
--- a/dynamodb/starter.js
+++ b/dynamodb/starter.js
@@ -8,7 +8,7 @@ var starter = {
         /* Dynamodb local documentation http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html */
         var additionalArgs = [],
             port = options.port || config.start.port,
-            db_dir = utils.absPath(config.setup.install_path),
+            db_dir = options.install_path || utils.absPath(config.setup.install_path),
             jar = config.setup.jar;
 
         if (options.dbPath) {

--- a/dynamodb/utils.js
+++ b/dynamodb/utils.js
@@ -4,8 +4,12 @@ var path = require('path'),
     rmdir = require('rmdir'),
     fs = require('fs');
 
-var absPath = function (relPath) {
-    return path.dirname(__filename) + '/' + relPath;
+var absPath = function (p) {
+  if (path.isAbsolute(p)) {
+    return p;
+  } else {
+    return path.join(path.dirname(__filename), p);
+  }
 };
 
 var removeDir = function (relPath, callback) {


### PR DESCRIPTION
Fixes: https://github.com/99xt/dynamodb-localhost/issues/22

This fixes the behavior of the localPath variable, and makes it possible to install dynamodb-local to an absolute path.

For the most part it implements the changes suggested in #22