### PR TITLE
Add error message for configuring/installing

### DIFF
--- a/dynamodb/installer.js
+++ b/dynamodb/installer.js
@@ -55,6 +55,8 @@ var install = function (config, callback) {
             utils.createDir(config.setup.install_path);
             download(download_url, install_path, callback);
         }
-    } catch (e) {}
+    } catch (err) {
+        throw new Error("Error configuring or installing Dynamodb local " + err);
+    }
 };
 module.exports.install = install;


### PR DESCRIPTION
When running `serverless dynamodb install` I was getting no error and it seemed to be installing, but I was having an issue with the directory not being correct.