### PR TITLE
Fix default `install_path` value to restore the previous behavior.

### DIFF
--- a/dynamodb/config.json
+++ b/dynamodb/config.json
@@ -1,7 +1,7 @@
 {
     "setup": {
         "download_url": "http://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.tar.gz",
-        "install_path": "/bin",
+        "install_path": "./bin",
         "jar": "DynamoDBLocal.jar"
     },
     "start": {


### PR DESCRIPTION
Please see also https://github.com/99xt/dynamodb-localhost/pull/24#issuecomment-417028276.