### PR TITLE
Add heapInitial and heapMax options

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,16 @@ NOTE: After executing start(options), DynamoDB will process incoming requests un
 
 All options for DynamoDB start:
 
-```
+```js
 { port : 8000, /* Port to listen on. Default: 8000 */
   cors : '*', /* Enable CORS support (cross-origin resource sharing) for JavaScript. You must provide a comma-separated "allow" list of specific domains. The default setting for cors is an asterisk (*), which allows public access. */
   inMemory : true, /* DynamoDB; will run in memory, instead of using a database file. When you stop DynamoDB;, none of the data will be saved. Note that you cannot specify both dbPath and inMemory at once. */
   dbPath : '<mypath>/', /* The directory where DynamoDB will write its database file. If you do not specify this option, the file will be written to the current directory. Note that you cannot specify both dbPath and inMemory at once. For the path, current working directory is <projectroot>/node_modules/dynamodb-localhost/dynamob. For example to create <projectroot>/node_modules/dynamodb-localhost/dynamob/<mypath> you should specify '<mypath>/' with a forwardslash at the end. */
   sharedDb : true, /* DynamoDB will use a single database file, instead of using separate files for each credential and region. If you specify sharedDb, all DynamoDB clients will interact with the same set of tables regardless of their region and credential configuration. */
   delayTransientStatuses : true, /* Causes DynamoDB to introduce delays for certain operations. DynamoDB can perform some tasks almost instantaneously, such as create/update/delete operations on tables and indexes; however, the actual DynamoDB service requires more time for these tasks. Setting this parameter helps DynamoDB simulate the behavior of the Amazon DynamoDB web service more closely. (Currently, this parameter introduces delays only for global secondary indexes that are in either CREATING or DELETING status.) */
-  optimizeDbBeforeStartup : true } /* Optimizes the underlying database tables before starting up DynamoDB on your computer. You must also specify -dbPath when you use this parameter. */
+  optimizeDbBeforeStartup : true,  /* Optimizes the underlying database tables before starting up DynamoDB on your computer. You must also specify -dbPath when you use this parameter. */
+  heapInitial: undefined, /* A string which sets the initial heap size e.g., heapInitial: '2048m'. This is input to the java -Xms argument */
+  heapMax: undefined, /* A string which sets the maximum heap size e.g., heapMax: '1g'. This is input to the java -Xmx argument */
 ```
 
 ## Links

--- a/dynamodb/starter.js
+++ b/dynamodb/starter.js
@@ -6,11 +6,18 @@ var spawn = require('child_process').spawn,
 var starter = {
     start: function (options, config) {
         /* Dynamodb local documentation http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html */
-        var additionalArgs = [],
+        var preArgs = [],
+            additionalArgs = [],
             port = options.port || config.start.port,
             db_dir = options.install_path || utils.absPath(config.setup.install_path),
             jar = config.setup.jar;
 
+        if (options.heapInitial) {
+            preArgs.push(`-Xms${options.heapInitial}`);
+        }
+        if (options.heapMax) {
+            preArgs.push(`-Xmx${options.heapMax}`)
+        }
         if (options.dbPath) {
             additionalArgs.push('-dbPath', options.dbPath);
         } else {
@@ -33,7 +40,7 @@ var starter = {
         }
 
         var args = ['-Djava.library.path=' + db_dir + '/DynamoDBLocal_lib', '-jar', jar, '-port', port];
-        args = args.concat(additionalArgs);
+        args = preArgs.concat(args.concat(additionalArgs));
 
         var child = spawn('java', args, {
             cwd: db_dir,


### PR DESCRIPTION
This PR adds two options: `heapInitial` and `heapMax`, which provide values to java's `-Xms` and `-Xmx` arguments. If not provided, java determines heap size dynamically, so this PR shouldn't change existing behavior.

## Why this is needed 

Java determines heap size dynamically. In some environments (for example, cloud CI), this can result in the heap being too small. If DynamoDB localhost runs out of memory, it will quit with a cryptic "Killed" message.

