### PR TITLE
Removed insecure dependency (Possible Fix)

### DIFF
--- a/dynamodb/utils.js
+++ b/dynamodb/utils.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var path = require('path'),
-    rmdir = require('rmdir'),
+    rimraf = require("rimraf"),
     fs = require('fs');
 
 var absPath = function (p) {
@@ -14,7 +14,7 @@ var absPath = function (p) {
 
 var removeDir = function (relPath, callback) {
     var path = absPath(relPath);
-    rmdir(path, callback);
+    rimraf(path, callback);
 };
 
 var createDir = function (relPath) {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "dependencies": {
         "mkdirp": "^0.5.0",
         "progress": "^1.1.8",
-        "rmdir": "^1.2.0",
+        "rimraf": "^2.6.3",
         "tar": "^2.0.0"
     }
 }


### PR DESCRIPTION
Replaces rmdir package with rimraf, rimraf is a widely used replacement to rmdir that does not have the same vulnerabilities. I saw the issue and didn't know how to proceed to help, I know there already is a PR on this issue. 

I have tested and this works on windows. Let me know if you need anything!