### PR TITLE
Downloading jar over https protocol

### DIFF
--- a/dynamodb/config.json
+++ b/dynamodb/config.json
@@ -1,6 +1,6 @@
 {
     "setup": {
-        "download_url": "http://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.tar.gz",
+        "download_url": "https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.tar.gz",
         "install_path": "./bin",
         "jar": "DynamoDBLocal.jar"
     },

--- a/dynamodb/installer.js
+++ b/dynamodb/installer.js
@@ -3,14 +3,14 @@
 var tar = require('tar'),
     zlib = require('zlib'),
     path = require('path'),
-    http = require('http'),
+    https = require('https'),
     fs = require('fs'),
     ProgressBar = require('progress'),
     utils = require('./utils');
 
 var download = function (downloadUrl, installPath, callback) {
     console.log("Started downloading Dynamodb-local. Process may take few minutes.");
-    http.get(downloadUrl, function (response) {
+    https.get(downloadUrl, function (response) {
             var len = parseInt(response.headers['content-length'], 10),
             bar = new ProgressBar('Downloading dynamodb-local [:bar] :percent :etas', {
                 complete: '=',


### PR DESCRIPTION
This change was made to avoid the error when install process is executed:

Error: Error getting DynamoDb local latest tar.gz location: 301
    at ClientRequest.<anonymous> (.../node_modules/serverless-dynamodb-local/node_modules/dynamodb-localhost/dynamodb/installer.js:14:26)
    at Object.onceWrapper (events.js:315:30)
    at emitOne (events.js:116:13)
    at ClientRequest.emit (events.js:211:7)
    at HTTPParser.parserOnIncomingClient [as onIncoming] (_http_client.js:551:21)
    at HTTPParser.parserOnHeadersComplete (_http_common.js:115:23)
    at Socket.socketOnData (_http_client.js:440:20)
    at emitOne (events.js:116:13)
    at Socket.emit (events.js:211:7)
    at addChunk (_stream_readable.js:263:12)
    at readableAddChunk (_stream_readable.js:250:11)
    at Socket.Readable.push (_stream_readable.js:208:10)
    at TCP.onread (net.js:607:20)
Error: Protocol "https:" not supported. Expected "http:"
    at new ClientRequest (_http_client.js:131:11)
    at request (http.js:38:10)
    at Object.get (http.js:42:13)
    at ClientRequest.<anonymous> (.../node_modules/serverless-dynamodb-local/node_modules/dynamodb-localhost/dynamodb/installer.js:16:18)
    at Object.onceWrapper (events.js:315:30)
    at emitOne (events.js:116:13)
    at ClientRequest.emit (events.js:211:7)
    at HTTPParser.parserOnIncomingClient [as onIncoming] (_http_client.js:551:21)
    at HTTPParser.parserOnHeadersComplete (_http_common.js:115:23)
    at Socket.socketOnData (_http_client.js:440:20)
    at emitOne (events.js:116:13)
    at Socket.emit (events.js:211:7)
    at addChunk (_stream_readable.js:263:12)
    at readableAddChunk (_stream_readable.js:250:11)
    at Socket.Readable.push (_stream_readable.js:208:10)
    at TCP.onread (net.js:607:20)