### PR TITLE
Fix for windows users using this library via 'serverless-dynamodb-local'

### DIFF
--- a/dynamodb/starter.js
+++ b/dynamodb/starter.js
@@ -45,6 +45,7 @@ var starter = {
         var child = spawn('java', args, {
             cwd: db_dir,
             env: process.env,
+            shell: true,
             stdio: ['pipe', 'pipe', process.stderr]
         });
 


### PR DESCRIPTION
Adding 'shell:true' to the starter.js file. This will fix issues that are affecting windows user when they are trying to start local dynamodb via the serverless-dynamodb-local package. The process starts and immediately shuts down.