### PR TITLE
Improve Dynamodb Local started message

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ var dynamodb = {
                 console.log('DynamoDB Local failed to start with code', code);
             }
         });
-        console.log('Dynamodb Local Started, Visit: http://localhost:' + (options.port || config.start.port) + '/shell');
+        console.log('Dynamodb Local Started: http://localhost:' + (options.port || config.start.port));
     },
     stop: function(port) {
         if (dbInstances[port]) {


### PR DESCRIPTION
# What is this?

DynamoDB Local Web Shell has been deprecated and the message at startup is inappropriate and seems to need improvement.
So I deleted the unwanted visit messages.

> DynamoDB Local Web Shell was deprecated with version 1.16.X and is not available any longer from 1.17.X to latest. 

See here: https://stackoverflow.com/questions/70535330/dynamodb-local-web-shell-does-not-load

## At amazon/dynamodb-local:1.16.0

With 1.16.0, DynamoDB Local Web Shell worked.

```shell
docker run -p 8000:8000 amazon/dynamodb-local:1.16.0
```

![1 16 0](https://user-images.githubusercontent.com/14287054/158480928-1c8088e3-ab7d-4292-9d2d-8d83c6e1a46d.png)

## At amazon/dynamodb-local:1.17.0

With 1.17.0, DynamoDB Local Web Shell does not work.

```shell
docker run -p 8000:8000 amazon/dynamodb-local:1.17.0
```

![1 17 0](https://user-images.githubusercontent.com/14287054/158480938-d2c81e51-810a-471f-8fdb-7ccd43ef9895.png)
