### PR TITLE
Make work with worker

### DIFF
--- a/dynamodb/config.json
+++ b/dynamodb/config.json
@@ -1,6 +1,6 @@
 {
   "setup": {
-    "download_url": "http://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.tar.gz",
+    "download_url": "https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.tar.gz",
     "install_path": "bin",
     "jar": "DynamoDBLocal.jar"
   },

--- a/dynamodb/installer.js
+++ b/dynamodb/installer.js
@@ -3,7 +3,7 @@
 var tar = require("tar"),
   zlib = require("zlib"),
   path = require("path"),
-  http = require("http"),
+  https = require("https"),
   fs = require("fs"),
   ProgressBar = require("progress"),
   utils = require("./utils");
@@ -12,7 +12,7 @@ var download = function(downloadUrl, installPath, callback) {
   console.log(
     `Started downloading dynamodb-local from ${downloadUrl} into ${installPath}. Process may take few minutes.`
   );
-  http
+  https
     .get(downloadUrl, function(response) {
       var len = parseInt(response.headers["content-length"], 10),
         bar = new ProgressBar(

--- a/dynamodb/starter.js
+++ b/dynamodb/starter.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var spawn = require('child_process').spawn,
+    isMainThread = require('worker_threads').isMainThread,
     utils = require('./utils');
 
 var starter = {
@@ -56,7 +57,7 @@ var starter = {
         var child = spawn(executable, args, {
             cwd: cwd,
             env: process.env,
-            stdio: ['pipe', 'pipe', process.stderr]
+            stdio: isMainThread ? ['pipe', 'pipe', process.stderr] : 'inherit'
         });
 
         if (!child.pid) {


### PR DESCRIPTION
I'm using dynamodb-localhost in vitest, it uses worker threads and as suggested https://github.com/vitest-dev/vitest/issues/1544 a check is required when spawning

Otherwise you get an error similar to

```js
TypeError [ERR_INVALID_ARG_VALUE]: The argument 'stdio' is invalid. Received WritableWorkerStdio {
  _writableState: WritableState {
    objectMode: false,
    highWaterMark: 16384,
    finalCalled: false,...
```