### PR TITLE
fix: update installer to use https for download

### DIFF
--- a/dynamodb/config.json
+++ b/dynamodb/config.json
@@ -1,6 +1,6 @@
 {
   "setup": {
-    "download_url": "http://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.tar.gz",
+    "download_url": "https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.tar.gz",
     "install_path": "bin",
     "jar": "DynamoDBLocal.jar"
   },

--- a/dynamodb/installer.js
+++ b/dynamodb/installer.js
@@ -3,7 +3,7 @@
 var tar = require("tar"),
   zlib = require("zlib"),
   path = require("path"),
-  http = require("http"),
+  https = require("https"),
   fs = require("fs"),
   ProgressBar = require("progress"),
   utils = require("./utils");
@@ -12,7 +12,7 @@ var download = function(downloadUrl, installPath, callback) {
   console.log(
     `Started downloading dynamodb-local from ${downloadUrl} into ${installPath}. Process may take few minutes.`
   );
-  http
+  https
     .get(downloadUrl, function(response) {
       var len = parseInt(response.headers["content-length"], 10),
         bar = new ProgressBar(


### PR DESCRIPTION
fix error with 403 on http://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.tar.gz