### PR TITLE
chore(bug): Update README + add async install

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,26 @@ Usage example
 
 ```
 var dynamodbLocal = require("dynamodb-localhost");
-dynamodbLocal.install(); /* This is one time operation. Safe to execute multiple times which installs DynamoDB once. All the other methods depends on this. */
-dynamodbLocal.start({port: 8000});
+/* Installation is one time operation. Safe to execute multiple times which installs DynamoDB once. All the other methods depends on this. */
+dynamodbLocal.install(function() {
+  dynamodbLocal.start({port: 8000});
+}); 
+```
+
+or
+
+```
+var dynamodbLocal = require("dynamodb-localhost");
+await dynamodbLocal.install();
+
+dynamodbLocal.start();
 ```
 
 Supported methods
 
 ```
-install(callback)   To install DynamoDB Local for usage (This is one time operation unless execute remove). 'callback' function is called after installation completes (or if already installed, immediately)
+install(callback)   To install DynamoDB Local for usage (This is one time operation unless remove is executed). 'callback' function is called after installation completes (or if already installed, immediately)
+installAsync()      To install DynamoDB Local asynchronously. Otherwise identical to install.
 start(options)      To start an instance of DynamoDB Local. More information about options shown in the coming section
 stop(port)          To stop particular instance of DynamoDb Local running on an specified port
 remove(callback)    To remove DynamoDB Local instance. 'callback' function is called after removal complete.

--- a/index.js
+++ b/index.js
@@ -16,6 +16,11 @@ var dynamodb = {
             callback();
         });
     },
+    installAsync: async function(path) {
+        return new Promise((resolve) => {
+            dynamodb.install(resolve, path);
+        });
+    },
     start: function(options) {
         var instance = starter.start(options, config);
         dbInstances[instance.port] = {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,21 +1,37 @@
 const fs = require("fs");
 const utils = require("../dynamodb/utils");
 const { expect } = require("chai");
-const { install, remove } = require("../index");
+const { install, remove, installAsync } = require("../index");
 const config = require("../dynamodb/config.json");
 
 describe("install", function() {
   const installPath = `./dynamodb/${config.setup.install_path}`;
   const jarPath = `${installPath}/${config.setup.jar}`;
 
+  beforeEach(() => {
+    if (fs.existsSync(jarPath)) {
+      fs.unlinkSync(jarPath);
+    }
+  });
+
   it("downloads the jar successfully", function(done) {
-    this.timeout(10000); // 10 second timeout
+    this.timeout(60000); // 60 second timeout
 
     install(function() {
       if (fs.existsSync(jarPath)) {
         done();
       }
     });
+  });
+
+  it("can download the jar async", async function() {
+    this.timeout(60000); // 60s timeout
+
+    await installAsync();
+
+    if (!fs.existsSync(jarPath)) {
+      throw new Error('Jar was not downloaded.');
+    }
   });
 
   it("removes the setup files", function(done) {


### PR DESCRIPTION
# What
- Adds `installAsync` as a non-breaking alternative to `install``
  - Removes need for callback
- Updates README to reflect need for install before start

# Why
Using the install method as-is results in a situation where at worst, the server cannot be started, and at best there's a race condition, as the following `start` method does _not_ wait for completion of the installation, and would subsequently fail
<img width="985" alt="image" src="https://user-images.githubusercontent.com/972446/232642514-99d0cb7a-c6ed-4372-9949-8da11b5fa09f.png">
Code run in the above screenshot:
```
var dynamodbLocal = require('dynamodb-localhost');
dynamodbLocal.install();
dynamodbLocal.start({port: 8000});
```